### PR TITLE
Fix deprecation warnings for platformio.ini

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install platformio
+        pip install wheel
         export BUILD_TAG=build-$(date -u +'%Y%m%d%H%M')
         echo "BUILD_TAG=$BUILD_TAG" >> $GITHUB_ENV
         

--- a/platformio.ini
+++ b/platformio.ini
@@ -62,7 +62,7 @@ build_src_filter =
     +<ILI9341_t3n/src/*.c>
     +<tft/*.cpp>
 
-build_src_filter =
+build_flags =
     ${common_env_data.build_flags}
     -Isrc/USBHost_t36
     -Isrc/ILI9341_t3n/src

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,7 +22,7 @@
 ;
 
 [common_env_data]
-build_src_filter =
+src_filter =
     +<*.cpp> +<*.c>
     +<n64/*.c>
     +<printf/*.c>

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,7 +22,7 @@
 ;
 
 [common_env_data]
-src_filter =
+build_src_filter =
     +<*.cpp> +<*.c>
     +<n64/*.c>
     +<printf/*.c>

--- a/platformio.ini
+++ b/platformio.ini
@@ -62,7 +62,7 @@ src_filter =
     +<ILI9341_t3n/src/*.c>
     +<tft/*.cpp>
 
-build_flags =
+build_src_filter =
     ${common_env_data.build_flags}
     -Isrc/USBHost_t36
     -Isrc/ILI9341_t3n/src

--- a/platformio.ini
+++ b/platformio.ini
@@ -55,7 +55,7 @@ monitor_speed = 256000
 ; Disable the inbuilt framework lib so I can use my own fork
 lib_ignore = USBHost_t36
 
-src_filter =
+build_src_filter =
     ${common_env_data.src_filter}
     +<USBHost_t36/*.cpp>
     +<ILI9341_t3n/src/*.cpp>


### PR DESCRIPTION
The current (successful) CI actions report deprecation warnings. These should be fixed as to not cause issues in future.

Fix deprecation warnings:
Use `pip install wheel` in CI, since package 'wheel' was not installed.
Replaced `src_filter` for `env:<target>`  with` build_src_filter` for `env:<target>`
