### PR TITLE
Fix legacy warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install platformio
         pip install wheel
+        pip install platformio
         export BUILD_TAG=build-$(date -u +'%Y%m%d%H%M')
         echo "BUILD_TAG=$BUILD_TAG" >> $GITHUB_ENV
         


### PR DESCRIPTION
Install wheel before platformio.
It was still producing a legacy warning:
![image](https://user-images.githubusercontent.com/11439699/191389375-dfd27e44-f2f0-4a66-8b7a-206430285678.png)

That warning is now not present:
![image](https://user-images.githubusercontent.com/11439699/191389892-4263adf7-37d4-4f8a-aa41-3359c6e7bc9b.png)
